### PR TITLE
New awscli broke awscli-keyring import paths

### DIFF
--- a/awscli_keyring/commands.py
+++ b/awscli_keyring/commands.py
@@ -4,7 +4,10 @@ import os
 from botocore.compat import OrderedDict
 
 from awscli.customizations.commands import BasicCommand
-from awscli.customizations.configure import ConfigFileWriter
+try:
+    from awscli.customizations.configure.writer import ConfigFileWriter
+except ImportError:
+    from awscli.customizations.configure import ConfigFileWriter
 
 from . import persistence
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='awscli-keyring',
-    version='0.1.2',
+    version='0.1.3',
     description='AWS command line credentials from OS X Keychain and other keyrings.',
     long_description='AWS command line credentials from OS X Keychain and other keyrings.',
     author='Samuel Cochran',


### PR DESCRIPTION
In [one of the recent changes](https://github.com/aws/aws-cli/commit/9c2fd8098a7cdfae00cc7505d3e82a06908f6552#diff-93a6972db772a156aa7f8abd788cb350), awscli changed some modules paths, breaking awscli-keyring.

This PR is trying to fix the issue.
